### PR TITLE
ci(actions): add auto-merge-on-green workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,23 @@
+# Auto-merge PRs labeled "automerge" once all required checks pass.
+# Uses GitHub native auto-merge; requires repo setting allow_auto_merge=true.
+name: Auto-merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: contains(github.event.pull_request.labels.*.name, 'automerge')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge on green
+        run: gh pr merge --auto --squash "${PR}"
+        env:
+          PR: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## Motivation

Enable hands-off merging of routine PRs (e.g. Renovate, cask bumps) once CI passes, reducing manual maintenance on this tap.

## Implementation information

- Adds `.github/workflows/auto-merge.yml`: enables GitHub native auto-merge (squash) on PRs labeled `automerge`, merging only after all required checks are green.
- Release intentionally skipped: this is a Homebrew tap whose cask is auto-updated by an external pipeline. `update-cask.yml` is driven by `repository_dispatch` from the upstream `Automaat/whisper-hotkey` app repo, so versioning/releases are handled externally and no release workflow is needed here.

> Changelog: skip