### PR TITLE
ci(renovate): enable platform automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
+  "automerge": true,
+  "automergeStrategy": "squash",
+  "platformAutomerge": true,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"


### PR DESCRIPTION
## Motivation

Enable Renovate platform automerge so dependency PRs merge automatically once CI is green (uses the repo's allow_auto_merge setting).

## Implementation information

Adds top-level `automerge: true`, `automergeStrategy: squash`, `platformAutomerge: true` to `renovate.json`, matching the convention already used in doctorine/environment-as-code.

> Changelog: skip